### PR TITLE
Add support for kubernetes service discovery by upgrading to v0.2.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,7 +7,7 @@ parameters:
       exporter_filterproxy:
         registry: ghcr.io
         repository: vshn/exporter-filterproxy
-        tag: v0.1.0
+        tag: v0.2.0
 
     replicas: 2
     resources:

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -24,6 +24,17 @@ local cluster_role = kube.ClusterRole('syn-exporter-filterproxy') {
       nonResourceURLs: [ '/metrics' ],
       verbs: [ 'get' ],
     },
+    {
+      apiGroups: [ '' ],
+      resources: [ 'endpoints' ],
+      verbs: [ 'get', 'watch', 'list' ],
+    },
+    {
+      apiGroups: [ '' ],
+      resources: [ 'nodes/metrics' ],
+      verbs: [ 'get' ],
+    },
+
   ],
 };
 local cluster_role_binding = kube.ClusterRoleBinding('syn-exporter-filterproxy') {

--- a/tests/golden/defaults/exporter-filterproxy/exporter-filterproxy/02_cluster_role.yaml
+++ b/tests/golden/defaults/exporter-filterproxy/exporter-filterproxy/02_cluster_role.yaml
@@ -12,3 +12,17 @@ rules:
       - /metrics
     verbs:
       - get
+  - apiGroups:
+      - ''
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - ''
+    resources:
+      - nodes/metrics
+    verbs:
+      - get

--- a/tests/golden/defaults/exporter-filterproxy/exporter-filterproxy/03_deployment.yaml
+++ b/tests/golden/defaults/exporter-filterproxy/exporter-filterproxy/03_deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --config
             - /etc/config/config.yml
           env: []
-          image: ghcr.io/vshn/exporter-filterproxy:v0.1.0
+          image: ghcr.io/vshn/exporter-filterproxy:v0.2.0
           imagePullPolicy: IfNotPresent
           name: proxy
           ports:


### PR DESCRIPTION
This PR updates the exporter-filterproxy to v0.2.0 and adds necessary new permissions.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
